### PR TITLE
Collection of small tweaks

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,6 +2,6 @@ block_labels = ["needs-decision"]
 delete_merged_branches = true
 required_approvals = 1
 status = [
-  "Clippy check",
-  "Code formatting check",
+  "clippy",
+  "rustfmt",
 ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "editor.formatOnSave": true,
-    "rust-analyzer.procMacro.enable": true,
-    "rust-analyzer.cargo.buildScripts.enable": true,
-    "rust-analyzer.imports.granularity.group": "module",
-}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,3 @@ restore-state-u8 = []
 restore-state-u16 = []
 restore-state-u32 = []
 restore-state-u64 = []
-
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ could be cases 1-4 from the above list.
 
 This crate solves the problem by providing this missing universal API.
 
-- It provides functions `acquire`, `release` and `free` that libraries can directly use.
+- It provides functions `acquire`, `release` and `with` that libraries can directly use.
 - It provides a way for any crate to supply an implementation. This allows "target support" crates such as architecture crates (`cortex-m`, `riscv`), RTOS bindings, or HALs for multicore chips to supply the correct impl so that all the crates in the dependency tree automatically use it.
 
 ## Providing an implementation
@@ -85,7 +85,7 @@ dual licensed as above, without any additional terms or conditions.
 ## Code of Conduct
 
 Contribution to this crate is organized under the terms of the [Rust Code of
-Conduct][CoC], the maintainer of this crate, the [Cortex-M team][team], promises
+Conduct][CoC], the maintainer of this crate, the [HAL team][team], promises
 to intervene to uphold that code of conduct.
 
 [CoC]: CODE_OF_CONDUCT.md

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,0 @@
-use std::env;
-
-fn main() {
-    let target = env::var("TARGET").unwrap();
-
-    if target.starts_with("thumbv") {
-        println!("cargo:rustc-cfg=cortex_m");
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ impl RestoreState {
 /// - `acquire`/`release` pairs must be "properly nested", ie it's not OK to do `a=acquire(); b=acquire(); release(a); release(b);`.
 /// - It is UB to call `release` if the critical section is not acquired in the current thread.
 /// - It is UB to call `release` with a "restore state" that does not come from the corresponding `acquire` call.
-#[inline]
+#[inline(always)]
 pub unsafe fn acquire() -> RestoreState {
     extern "Rust" {
         fn _critical_section_1_0_acquire() -> RawRestoreState;
@@ -184,7 +184,7 @@ pub unsafe fn acquire() -> RestoreState {
 /// # Safety
 ///
 /// See [`acquire`] for the safety contract description.
-#[inline]
+#[inline(always)]
 pub unsafe fn release(restore_state: RestoreState) {
     extern "Rust" {
         fn _critical_section_1_0_release(restore_state: RawRestoreState);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use self::mutex::Mutex;
 /// section.
 #[derive(Clone, Copy, Debug)]
 pub struct CriticalSection<'cs> {
-    _0: PhantomData<&'cs ()>,
+    _private: PhantomData<&'cs ()>,
 }
 
 impl<'cs> CriticalSection<'cs> {
@@ -36,7 +36,9 @@ impl<'cs> CriticalSection<'cs> {
     /// inferred to `'static`.
     #[inline(always)]
     pub unsafe fn new() -> Self {
-        CriticalSection { _0: PhantomData }
+        CriticalSection {
+            _private: PhantomData,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub type RawRestoreState = RawRestoreStateInner;
 ///
 /// User code uses [`RestoreState`] opaquely, critical section implementations
 /// use [`RawRestoreState`] so that they can use the inner value.
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct RestoreState(RawRestoreState);
 
@@ -188,6 +189,7 @@ pub unsafe fn release(restore_state: RestoreState) {
     extern "Rust" {
         fn _critical_section_1_0_release(restore_state: RawRestoreState);
     }
+
     #[allow(clippy::unit_arg)]
     _critical_section_1_0_release(restore_state.0)
 }


### PR DESCRIPTION
* Remove `build.rs`, since it doesn't seem like the `cortex_m` cfg is used any more
* Remove `docsrs` config in `Cargo.toml` which also doesn't seem to be used any more
* Remove `.vscode` files which don't belong in the repository
* Fix `free`/`with` typo in README
* Fix team name in README
* Make `RestoreState` be `repr(transparent)` to ensure it's always the same as the underlying raw state
* Make `acquire` and `release` be `inline(always)` since they always directly call the exported functions
* Add a newline to `lib.rs` to make `release` consistent with `acquire`
* Renamed the `_0` field to `_private`

To consider:
* ~Make `with` also be `inline(always)`? It's not as trivial as `acquire`/`release` so I'm not sure this is really needed~
* ~Change `CriticalSection` to be a tuple struct i.e. `pub struct CriticalSection<'cs>(PhantomData<&'cs ()>)` since the only named field is `_0` anyway. Not sure if there's any compatibility hazards here.~