### PR TITLE
Use critical-section 1.1.1 internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet
+- Implemented critical-section by forwarding to version 1.1.1
+
+Breaking changes:
+
+- `acquire` and `release` are only implemented if the restore-state used by
+  version 1.1.1 is an u8 or smaller.
+- No default critical-section implementation is provided.
+
+Those breaking changes are necessary because versions <= 0.2.7 were unsound, and that
+was impossible to fix without a breaking change.
+
+This version is meant to minimize that breaking change. However, all
+users are encouraged to upgrade to critical-section 1.1.
 
 ## 0.2.7 - 2022-04-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "critical-section"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2018"
 description = "Critical section abstraction"
@@ -14,29 +14,11 @@ categories = [
 ]
 
 [features]
-custom-impl = []
+custom-impl = ["critical-section_1/restore-state-u8"]
 
 [dependencies]
 bare-metal = "1.0.0"
-cfg-if = "1.0.0"
-
-[target.thumbv6m-none-eabi.dependencies]
-cortex-m = "0.7.2"
-[target.thumbv7em-none-eabi.dependencies]
-cortex-m = "0.7.2"
-[target.thumbv7em-none-eabihf.dependencies]
-cortex-m = "0.7.2"
-[target.thumbv7m-none-eabi.dependencies]
-cortex-m = "0.7.2"
-[target."thumbv8m.base-none-eabi".dependencies]
-cortex-m = "0.7.2"
-[target."thumbv8m.main-none-eabi".dependencies]
-cortex-m = "0.7.2"
-[target."thumbv8m.main-none-eabihf".dependencies]
-cortex-m = "0.7.2"
-
-[target.'cfg(target_arch = "riscv32")'.dependencies]
-riscv = {version = "0.7.0"}
+critical-section_1 = { package = "critical-section", version = "1.1.1" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -26,17 +26,24 @@ could be cases 1-4 from the above list.
 This crate solves the problem by providing this missing universal API.
 
 - It provides functions `acquire`, `release` and `free` that libraries can directly use.
-- It provides some built-in impls for well-known targets, so in many cases it Just Works.
+- ~~It provides some built-in impls for well-known targets, so in many cases it Just Works.~~
 - It provides a way for any crate to supply a "custom impl" that overrides the built-in one. This allows environment-support crates such as RTOS bindings or HALs for multicore chips to supply the correct impl so that all the crates in the dependency tree automatically use it.
 
 ## Built-in impls
 
+Versions up to 0.2.7 provided default built-in impls for some architectures. Those were
+only sound in single-core privileged mode. Because they were unsound in other situations,
+and there is no way to detect those situations at compile-time, those implementations
+were removed in version 0.2.8.
 
-| Target             | Mechanism                 | Notes |
-|--------------------|---------------------------|-------------------|
-| thumbv[6-8]        | `cpsid` / `cpsie`.        | Only sound in single-core privileged mode. |
-| riscv32*           | set/clear `mstatus.mie`   | Only sound in single-core privileged mode. |
-| std targets        | Global `std::sync::Mutex` |  |
+If the build fails with a (possibly long) linker error message, containing
+text like `error: undefined symbol: _critical_section_1_0_acquire`, that's caused by
+those missing implementations.
+
+To fix the build, you should add a dependency on `critical-section = "1.1"`, and
+[provide a critical-section implementation](https://crates.io/crates/critical-section#usage-in-no-std-binaries).
+
+If possible, you should also remove the dependency on version 0.2.x.
 
 ## Providing a custom impl
 

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,0 @@
-use std::env;
-
-fn main() {
-    let target = env::var("TARGET").unwrap();
-
-    if target.starts_with("thumbv") {
-        println!("cargo:rustc-cfg=cortex_m");
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
-#![cfg_attr(target_arch = "avr", feature(llvm_asm))]
-#![cfg_attr(target_arch = "avr", feature(extended_key_value_attributes))]
 #![doc = include_str!("../README.md")]
 
 pub use bare_metal::CriticalSection;
@@ -20,13 +18,13 @@ pub use bare_metal::CriticalSection;
 /// - `acquire`/`release` pairs must be "properly nested", ie it's not OK to do `a=acquire(); b=acquire(); release(a); release(b);`.
 /// - It is UB to call `release` if the critical section is not acquired in the current thread.
 /// - It is UB to call `release` with a restore token that does not come from the corresponding `acquire` call.
+#[allow(clippy::unit_arg)]
 #[inline]
 pub unsafe fn acquire() -> u8 {
     extern "Rust" {
-        fn _critical_section_acquire() -> u8;
+        fn _critical_section_1_0_acquire() -> critical_section_1::RawRestoreState;
     }
-
-    _critical_section_acquire()
+    _critical_section_1_0_acquire().to_u8()
 }
 
 /// Release the critical section.
@@ -36,12 +34,13 @@ pub unsafe fn acquire() -> u8 {
 /// # Safety
 ///
 /// See [`acquire`] for the safety contract description.
+#[allow(clippy::unit_arg)]
 #[inline]
 pub unsafe fn release(token: u8) {
     extern "Rust" {
-        fn _critical_section_release(token: u8);
+        fn _critical_section_1_0_release(restore_state: critical_section_1::RawRestoreState);
     }
-    _critical_section_release(token)
+    _critical_section_1_0_release(critical_section_1::RawRestoreState::from_u8(token));
 }
 
 /// Execute closure `f` in a critical section.
@@ -50,149 +49,66 @@ pub unsafe fn release(token: u8) {
 /// are mostly no-ops since they're already protected by the outer one.
 #[inline]
 pub fn with<R>(f: impl FnOnce(CriticalSection) -> R) -> R {
-    unsafe {
-        let token = acquire();
-        let r = f(CriticalSection::new());
-        release(token);
-        r
+    critical_section_1::with(|_| f(unsafe { CriticalSection::new() }))
+}
+
+// Extension trait which implements conversions between ResultState and u8, if possible
+trait ConvertResultState {
+    fn to_u8(self) -> u8;
+    fn from_u8(state: u8) -> Self;
+}
+
+impl ConvertResultState for () {
+    fn to_u8(self) -> u8 {
+        0
+    }
+
+    fn from_u8(_state: u8) -> Self {}
+}
+
+impl ConvertResultState for bool {
+    fn to_u8(self) -> u8 {
+        self.into()
+    }
+
+    fn from_u8(state: u8) -> Self {
+        state == 1
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "custom-impl")] {
-        /// Methods required for a custom critical section implementation.
-        ///
-        /// This trait is not intended to be used except when implementing a custom critical section.
-        ///
-        /// Implementations must uphold the contract specified in [`crate::acquire`] and [`crate::release`].
-        #[cfg_attr(docsrs, doc(cfg(feature = "custom-impl")))]
-        pub unsafe trait Impl {
-            /// Acquire the critical section.
-            unsafe fn acquire() -> u8;
-            /// Release the critical section.
-            unsafe fn release(token: u8);
-        }
+impl ConvertResultState for u8 {
+    fn to_u8(self) -> u8 {
+        self
+    }
 
-        /// Set the custom critical section implementation.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// struct MyCriticalSection;
-        /// critical_section::custom_impl!(MyCriticalSection);
-        ///
-        /// unsafe impl critical_section::Impl for MyCriticalSection {
-        ///     unsafe fn acquire() -> u8 {
-        ///         // ...
-        ///         # return 0
-        ///     }
-        ///
-        ///     unsafe fn release(token: u8) {
-        ///         // ...
-        ///     }
-        /// }
-        ///
-        #[cfg_attr(docsrs, doc(cfg(feature = "custom-impl")))]
-        #[macro_export]
-        macro_rules! custom_impl {
-            ($t: ty) => {
-                #[no_mangle]
-                unsafe fn _critical_section_acquire() -> u8 {
-                    <$t as $crate::Impl>::acquire()
-                }
-                #[no_mangle]
-                unsafe fn _critical_section_release(token: u8) {
-                    <$t as $crate::Impl>::release(token)
-                }
-            };
-        }
-    } else if #[cfg(cortex_m)] {
-        #[no_mangle]
-        unsafe fn _critical_section_acquire() -> u8 {
-            let primask = cortex_m::register::primask::read();
-            cortex_m::interrupt::disable();
-            primask.is_active() as _
-        }
-
-        #[no_mangle]
-        unsafe fn _critical_section_release(token: u8) {
-            if token != 0 {
-                cortex_m::interrupt::enable()
-            }
-        }
-    } else if #[cfg(target_arch = "avr")] {
-        #[no_mangle]
-        unsafe fn _critical_section_acquire() -> u8 {
-            let mut sreg: u8;
-            llvm_asm!(
-                "in $0, 0x3F
-                 cli"
-                : "=r"(sreg)
-                ::: "volatile"
-            );
-            sreg
-        }
-
-        #[no_mangle]
-        unsafe fn _critical_section_release(token: u8) {
-            if token & 0x80 == 0x80 {
-                llvm_asm!("sei" :::: "volatile");
-            }
-        }
-    } else if #[cfg(target_arch = "riscv32")] {
-        #[no_mangle]
-        unsafe fn _critical_section_acquire() -> u8 {
-            let interrupts_active = riscv::register::mstatus::read().mie();
-            riscv::interrupt::disable();
-            interrupts_active as _
-        }
-
-        #[no_mangle]
-        unsafe fn _critical_section_release(token: u8) {
-            if token != 0 {
-                riscv::interrupt::enable();
-            }
-        }
-    } else if #[cfg(any(unix, windows, wasm, target_arch = "wasm32"))] {
-        extern crate std;
-        use std::sync::{Once, Mutex, MutexGuard};
-        use core::cell::Cell;
-
-        static INIT: Once = Once::new();
-        static mut GLOBAL_LOCK: Option<Mutex<()>> = None;
-        static mut GLOBAL_GUARD: Option<MutexGuard<'static, ()>> = None;
-
-        std::thread_local!(static IS_LOCKED: Cell<bool> = Cell::new(false));
-
-        #[no_mangle]
-        unsafe fn _critical_section_acquire() -> u8 {
-            INIT.call_once(|| unsafe {
-                GLOBAL_LOCK.replace(Mutex::new(()));
-            });
-
-            // Allow reentrancy by checking thread local state
-            IS_LOCKED.with(|l| {
-                if !l.get() {
-                    let guard = GLOBAL_LOCK.as_ref().unwrap().lock().unwrap();
-                    GLOBAL_GUARD.replace(guard);
-                    l.set(true);
-                    1
-                } else {
-                    0
-                }
-            })
-        }
-
-        #[no_mangle]
-        unsafe fn _critical_section_release(token: u8) {
-            if token == 1 {
-                GLOBAL_GUARD.take();
-                IS_LOCKED.with(|l| {
-                    l.set(false);
-                });
-            }
-        }
-    } else {
-        compile_error!("Critical section is not implemented for this target. Make sure you've specified the correct --target. You may need to supply a custom critical section implementation with the `custom-impl` feature");
+    fn from_u8(state: u8) -> Self {
+        state
     }
 }
+
+// These should never be called, as `acquire`/`release` now call
+// the critical-section 1.0 implementations, directly.
+//
+// However, if somehow an version <= 0.2.7 of critical-section gets
+// linked in, it may reference the old names.
+
+#[allow(clippy::unit_arg)]
+#[no_mangle]
+unsafe fn _critical_section_acquire() -> u8 {
+    extern "Rust" {
+        fn _critical_section_1_0_acquire() -> critical_section_1::RawRestoreState;
+    }
+    _critical_section_1_0_acquire().to_u8()
+}
+
+#[allow(clippy::unit_arg)]
+#[no_mangle]
+unsafe fn _critical_section_release(token: u8) {
+    extern "Rust" {
+        fn _critical_section_1_0_release(restore_state: critical_section_1::RawRestoreState);
+    }
+    _critical_section_1_0_release(critical_section_1::RawRestoreState::from_u8(token));
+}
+
+#[cfg(feature = "custom-impl")]
+pub use critical_section_1::{set_impl as custom_impl, Impl};


### PR DESCRIPTION
With this change, this version becomes an empty stub, forwarding all calls to version 1.1.1 if possible.

This is part of the fix for #30. Next step (after releasing 0.2.8) would be yanking older versions.