### PR TITLE
Remove misleading use of CriticalSection::new from Mutex docs

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,8 +2,9 @@ name: Clippy check
 
 on:
   push:
-    branches: [ staging, trying, main ]
+    branches: [ main ]
   pull_request:
+  merge_group:
 
 jobs:
   clippy:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -2,8 +2,9 @@ name: Code formatting check
 
 on:
   push:
-    branches: [ staging, trying, main ]
+    branches: [ main ]
   pull_request:
+  merge_group:
 
 jobs:
   rustfmt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ staging, trying, main ]
+    branches: [ main ]
   pull_request:
+  merge_group:
 
 jobs:
   test:

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -29,21 +29,22 @@ use core::cell::{Ref, RefCell, RefMut, UnsafeCell};
 /// To reduce verbosity when using `Mutex<RefCell<T>>`, we reimplement some of
 /// `RefCell`'s methods on it directly.
 ///
-/// ```
-/// # use critical_section::{CriticalSection, Mutex};
+/// ```no_run
+/// # use critical_section::Mutex;
 /// # use std::cell::RefCell;
 ///
 /// static FOO: Mutex<RefCell<i32>> = Mutex::new(RefCell::new(42));
 ///
 /// fn main() {
-///     let cs = unsafe { CriticalSection::new() };
-///     // Instead of calling this
-///     let _ = FOO.borrow(cs).take();
-///     // Call this
-///     let _ = FOO.take(cs);
-///     // `RefCell::borrow` and `RefCell::borrow_mut` are renamed to
-///     // `borrow_ref` and `borrow_ref_mut` to avoid name collisions
-///     let _: &mut i32 = &mut *FOO.borrow_ref_mut(cs);
+///     critical_section::with(|cs| {
+///         // Instead of calling this
+///         let _ = FOO.borrow(cs).take();
+///         // Call this
+///         let _ = FOO.take(cs);
+///         // `RefCell::borrow` and `RefCell::borrow_mut` are renamed to
+///         // `borrow_ref` and `borrow_ref_mut` to avoid name collisions
+///         let _: &mut i32 = &mut *FOO.borrow_ref_mut(cs);
+///     })
 /// }
 /// ```
 ///


### PR DESCRIPTION
This tripped someone up in Matrix today. I think it's a legacy artefact of the `bare-metal` days so should be fixed now that it's in `critical-section`.

That said, this might be a good chance to improve on the example or add another example showing typical `Mutex` use - any ideas?