### PR TITLE
Mitigate Miri violation

### DIFF
--- a/src/std.rs
+++ b/src/std.rs
@@ -46,7 +46,8 @@ unsafe impl crate::Impl for StdCriticalSection {
             // SAFETY: As per the acquire/release safety contract, release can only be called
             // if the critical section is acquired in the current thread,
             // in which case we know the GLOBAL_GUARD is initialized.
-            GLOBAL_GUARD.assume_init_drop();
+            #[allow(let_underscore_lock)]
+            let _ = GLOBAL_GUARD.assume_init_read();
 
             // Note: it is fine to clear this flag *after* releasing the mutex because it's thread local.
             // No other thread can see its value, there's no potential for races.


### PR DESCRIPTION
While testing an [embassy](https://embassy.dev/) project on Windows using Miri, I encountered a hard-to-diagnose violation involving a conflict between writing to and dropping critical-section's `GLOBAL_GUARD`.

I believe the change proposed in this PR is low-risk and should work exactly the same as before while appeasing Miri and potentially mitigating a program bug.

### Minimal project to produce Miri complaint:

Cargo.toml:
```
// ...
[dependencies]
embassy-executor = { version = "0.5.0", features = ["task-arena-size-131072", "arch-std", "executor-thread", "integrated-timers"] }
embassy-time = { version = "0.3.0", features = ["std"] }
```

main.rs:
```
#[embassy_executor::main]
async fn main(_spawner: embassy_executor::Spawner) {
    loop {
        embassy_time::Timer::after_millis(1000).await;
    }
}
```

Miri command (on Windows): `cargo +nightly-2024-04-10 miri run`

Sample output:
```
error: Undefined Behavior: not granting access to tag <39012> because that would remove [Unique for <38804>] which is strongly protected because it is an argument of call 8084
   --> C:\...\lib\rustlib\src\rust\library\core\src\mem\maybe_uninit.rs:493:24      
    |
493 |     pub const fn write(&mut self, val: T) -> &mut T {
    |                        ^^^^^^^^^ not granting access to tag <39012> because that would remove [Unique for <38804>] which is strongly protected because it is an argument of call 8084
```
