### PR TITLE
Fix building with restore-state-usize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,8 @@ impl RestoreState {
             feature = "restore-state-u8",
             feature = "restore-state-u16",
             feature = "restore-state-u32",
-            feature = "restore-state-u64"
+            feature = "restore-state-u64",
+            feature = "restore-state-usize"
         )))]
         return Self(());
 
@@ -162,6 +163,9 @@ impl RestoreState {
         return Self(0);
 
         #[cfg(feature = "restore-state-u64")]
+        return Self(0);
+
+        #[cfg(feature = "restore-state-usize")]
         return Self(0);
     }
 }


### PR DESCRIPTION
For reasons I'm still investigating (that is, how this got by all tests), a bug sneaked into #40, so things don't even build with that feature enabled.

This PR fixes it; leaving it as a draft until I have a full post-mortem.

Sorry for introducing this in the first place (and then even pushing for a release, relying on my tests back then).