### PR TITLE
Replace UnsafeCell with MaybeUnit

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,11 +2,11 @@ block_labels = ["needs-decision"]
 delete_merged_branches = true
 required_approvals = 1
 status = [
-  "clippy (1.54)",
+  "clippy (1.55)",
   "clippy (1.63)",
   "clippy (1.63, std)",
   "rustfmt",
-  "test (1.54)",
+  "test (1.55)",
   "test (1.63)",
   "test (1.63, std)",
 ]

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.54
+          - rust: 1.55
             features: ''
           - rust: 1.63
             features: ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.54
+          - rust: 1.55
             features: ''
           - rust: 1.63
             features: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet
+- Use `MaybeUninit` instead of `UnsafeCell`, internally.
+- MSRV changed to `1.55` when `std` feature is disabled.
 
 ## [v1.1.3] - 2024-08-22
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ which would be unsound.
 
 This crate is guaranteed to compile on the following Rust versions:
 
-- If the `std` feature is not enabled: stable Rust 1.54 and up.
+- If the `std` feature is not enabled: stable Rust 1.55 and up.
 - If the `std` feature is enabled: stable Rust 1.63 and up.
 
 It might compile with older versions but that may change in any new patch release.


### PR DESCRIPTION
This leads to slightly better code generation in some cases where the mutex contents are accessed multiple times in a row.

Closes: #52 