### PR TITLE
Add `from_raw` and `into_raw` methods to `RestoreState`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet.
+- Add `from_raw` and `into_raw` methods to `RestoreState`.
 
 ## [v1.3.0] - 2026-06-02
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,16 @@ pub type RawRestoreState = RawRestoreStateInner;
 pub struct RestoreState(RawRestoreState);
 
 impl RestoreState {
+    /// Creates a restore state from its raw representation.
+    pub fn from_raw(raw_restore_state: RawRestoreState) -> Self {
+        Self(raw_restore_state)
+    }
+
+    /// Converts this restore state into its raw representation.
+    pub fn into_raw(self) -> RawRestoreState {
+        self.0
+    }
+
     /// Create an invalid, dummy  `RestoreState`.
     ///
     /// This can be useful to avoid `Option` when storing a `RestoreState` in a


### PR DESCRIPTION
I have a use case where I need to re-expose `_critical_section_1_0_acquire`/`_critical_section_1_0_release` to a shared library that is dynamically loaded.

Specifically, using the `elf_loader` crate, I need to do this:

```rust
unsafe fn _critical_section_1_0_acquire() -> RawRestoreState {
  unsafe { critical_section::acquire().into_raw() }
}

unsafe fn _critical_section_1_0_release(restore_state: RawRestoreState) {
  unsafe { critical_section::release(RestoreState::from_raw(restore_state)) };
}


 SyntheticModule::new(
  "__host",
  [
    SyntheticSymbol::function(
      "_critical_section_1_0_acquire",
      _critical_section_1_0_acquire as *const (),
    ),
    SyntheticSymbol::function(
      "_critical_section_1_0_release",
      _critical_section_1_0_release as *const (),
    ),
  ],
)
```
